### PR TITLE
Fix code scanning alert #5: Overly permissive regular expression range

### DIFF
--- a/src/languages/powershell.js
+++ b/src/languages/powershell.js
@@ -107,8 +107,8 @@ export default function(hljs) {
       VAR,
       {
         className: 'variable',
-        begin: /\$[A-z]/,
-        end: /[^A-z]/
+        begin: /\$[A-Za-z]/,
+        end: /[^A-Za-z]/
       }
     ]
   };


### PR DESCRIPTION
Fixes [https://github.com/cooljeanius/highlight.js/security/code-scanning/5](https://github.com/cooljeanius/highlight.js/security/code-scanning/5)

_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
